### PR TITLE
site: add line numbers to long examples

### DIFF
--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -51,10 +51,17 @@
     }
 
     function trustExample(example) {
+      var MIN_CODE_LINES = 10;
+      var useLineNumbers = false;
+      var openTag = '<span class="code-block__line">';
+      var closeTag = '</span>';
       var code, caption;
 
       if (example.code) {
-        code = $sce.trustAsHtml(example.code);
+        code = example.code.split('\n');
+        useLineNumbers = code.length > MIN_CODE_LINES;
+        code = openTag + code.join(closeTag + '\n' + openTag) + closeTag;
+        code = $sce.trustAsHtml(code);
       }
 
       if (example.caption) {
@@ -63,7 +70,8 @@
 
       return {
         code: code,
-        caption: caption
+        caption: caption,
+        useLineNumbers: useLineNumbers
       };
     }
 

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -69,7 +69,7 @@
       <h4>Example</h4>
       <div ng-repeat="example in method.examples">
         <div ng-if="example.caption" bind-html-compile="example.caption"></div>
-        <div ng-if="example.code" class="code-block">
+        <div ng-if="example.code" class="code-block" ng-class="{'code-block--numbers': example.useLineNumbers}">
           <pre><code class="hljs {{::markdown}}" bind-html-compile="example.code"></code></pre>
         </div>
       </div>

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -141,6 +141,21 @@ pre {
   font-size: 1em;
 }
 
+.code-block--numbers {
+  & > pre {
+    counter-reset:line;
+  }
+
+  .code-block__line:before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    padding: 0 0.5em;
+    margin-right: 0.5em;
+    color: #998;
+  }
+}
+
 pre,
 code {
   font-family: Monaco, 'Droid Sans Mono', monospace !important;


### PR DESCRIPTION
Closes #121 

I decided to take a crack at this using @stephenplusplus suggestion of CSS counters. If possible I appreciate some feedback in regards to the styling of the line numbers.

Preview
<img width="781" alt="screen shot 2016-04-08 at 11 08 47 am" src="https://cloud.githubusercontent.com/assets/1707267/14388137/abe01464-fd7a-11e5-8643-a37609a9aa62.png">

[demo](http://callmehiphop.github.io/gcloud-node/#/docs/v0.29.0/storage?method=getBuckets)
