### PR TITLE
Specify C# namespace in test proto

### DIFF
--- a/testing/firestore/proto/test.proto
+++ b/testing/firestore/proto/test.proto
@@ -4,6 +4,8 @@ syntax = "proto3";
 
 package tests;
 
+option csharp_namespace = "Google.Cloud.Firestore.Tests.Proto";
+
 import "google/firestore/v1beta1/firestore.proto";
 import "google/firestore/v1beta1/common.proto";
 


### PR DESCRIPTION
This just makes the generated C# code slightly more idiomatic.
It doesn't require any changes to the tests or the binary result.