### PR TITLE
site: add support for redirecting to new docs

### DIFF
--- a/site/src/app/components/module-switcher/module-switcher.directive.js
+++ b/site/src/app/components/module-switcher/module-switcher.directive.js
@@ -6,16 +6,28 @@
     .directive('moduleSwitcher', moduleSwitcher);
 
   /** @ngInject */
-  function moduleSwitcher($stateParams, manifest, util) {
+  function moduleSwitcher($state, manifest, util) {
     return {
       restrict: 'A',
       templateUrl: 'app/components/module-switcher/module-switcher.html',
       link: function(scope) {
         scope.modules = manifest.modules;
 
-        scope.$watch($stateParams, function() {
+        scope.getUrl = function(module) {
+          if (module.redirectTo) {
+            return module.redirectTo;
+          }
+
+          return $state.href('docs.service', {
+            module: module.id,
+            version: module.versions[0],
+            serviceId: module.defaultService
+          });
+        };
+
+        scope.$watch($state.params, function() {
           var module = util.findWhere(manifest.modules, {
-            id: $stateParams.module
+            id: $state.params.module
           });
 
           scope.selected = module.name;

--- a/site/src/app/components/module-switcher/module-switcher.html
+++ b/site/src/app/components/module-switcher/module-switcher.html
@@ -1,10 +1,11 @@
 <dropdown selected="selected" class="module-switcher">
   <li ng-repeat="module in modules">
     <a
-      ui-sref="docs.service({ module: module.id, version: module.versions[0], serviceId: module.defaultService })"
+      class="skip-external-link"
+      ng-href="{{::getUrl(module)}}"
       ng-attr-title="{{::module.name}}">
         <span class="module-name">{{::module.name}}</span>
-        <span class="module-version">latest: {{::module.versions[0]}}</span>
+        <span ng-if="::module.versions" class="module-version">latest: {{::module.versions[0]}}</span>
       </a>
   </li>
 </dropdown>

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -6,12 +6,13 @@
     .controller('DocsCtrl', DocsCtrl);
 
   /** @ngInject */
-  function DocsCtrl($state, langs, manifest, toc, types, lastBuiltDate, versions) {
+  function DocsCtrl($state, langs, manifest, toc, types, lastBuiltDate, versions, util) {
     var docs = this;
 
     docs.libraryTitle = manifest.libraryTitle || 'Google Cloud';
     docs.langs = langs;
     docs.lastBuiltDate = lastBuiltDate;
+    docs.latestDocsUrl = getNewDocsUrl();
     docs.guides = toc.guides;
     docs.services = toc.services;
     docs.versions = versions;
@@ -69,6 +70,24 @@
 
     function getGuideUrl(page) {
       return page.title.toLowerCase().replace(/\s/g, '-');
+    }
+
+    function getNewDocsUrl() {
+      if (manifest.latestDocsUrl) {
+        return manifest.latestDocsUrl;
+      }
+
+      if (manifest.modules) {
+        var mod = util.findWhere(manifest.modules, {
+          id: $state.params.module
+        });
+
+        if (mod) {
+          return mod.latestDocsUrl;
+        }
+      }
+
+      return null;
     }
   }
 }());

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -1,5 +1,11 @@
 <page-header title="service.title"></page-header>
 <version-switcher class="invisible-lg side-nav--meta--top"></version-switcher>
+<article ng-if="::docs.latestDocsUrl" class="docs-moved">
+  <p>
+    Can't find the right version? That might be because our docs have
+    <a ng-href="{{::docs.latestDocsUrl}}">moved</a>
+  </p>
+</article>
 <article class="content">
   <div ng-if="::docs.overviewFileUrl">
     <h3 class="sub-heading toggle" ng-click="service.showGettingStarted = !service.showGettingStarted">

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -872,6 +872,14 @@ ul {
     border-bottom: 1px solid rgba(0,0,0,0.05);
 }
 
+.docs-moved {
+  background-color: #db4437;
+  color: #fff;
+  padding: 0.25em 1.5em;
+  margin-bottom: 1em;
+  margin-top: -10px;
+}
+
 .param {
   white-space: nowrap;
 }
@@ -1630,8 +1638,9 @@ ul {
         background: url(../assets/images/lang-bg.png) repeat-y;
     }
 
-    .docs-header {
+    .docs-header, .docs-moved {
       margin-left: 240px;
+      margin-top: 0;
     }
 
     .content {


### PR DESCRIPTION
This PR does two things

1. Allows specifying a link in the modules dropdown to redirect the user somewhere else. This is useful for new modules and/or modules we don't need to preserve old docs for.
2. Displays a message if it detects that the docs have moved, containing a link to said docs.

Mobile:
<img width="386" alt="screen shot 2017-11-27 at 9 21 31 am" src="https://user-images.githubusercontent.com/1707267/33271391-19a343f2-d355-11e7-82da-4bbbb542433c.png">

Desktop:
<img width="1075" alt="screen shot 2017-11-27 at 9 21 16 am" src="https://user-images.githubusercontent.com/1707267/33271394-1b67b33a-d355-11e7-9928-89014841ae5f.png">
