### PR TITLE
Fix contributing readme numbering

### DIFF
--- a/contributing/readme.md
+++ b/contributing/readme.md
@@ -51,9 +51,9 @@ The following is a high-level overview of how to contribute to a Google Cloud cl
 
 1. Clone the project repository from GitHub.
 
-  ```sh
-  $ git clone git@github.com:GoogleCloudPlatform/<project-name>.git
-  ```
+    ```sh
+    $ git clone git@github.com:GoogleCloudPlatform/<project-name>.git
+    ```
 
 1. Set up your local development environment.
 
@@ -61,9 +61,9 @@ The following is a high-level overview of how to contribute to a Google Cloud cl
 
 1. Create a new local branch.
 
-  ```sh
-  $ git checkout -b <new-issue-name>
-  ```
+    ```sh
+    $ git checkout -b <new-issue-name>
+    ```
 
 1. Make changes. Be sure to edit or add API documentation for your changes.
 
@@ -79,15 +79,15 @@ The following is a high-level overview of how to contribute to a Google Cloud cl
 
 1. Add your fork as a remote to your local repository:
 
-  ```sh
-  $ git remote add <your-username> git@github.com:<your-username>/<project-name>.git
-  ```
+    ```sh
+    $ git remote add <your-username> git@github.com:<your-username>/<project-name>.git
+    ```
 
 1. Push your branch to your fork.
 
-  ```sh
-  $ git push <your-username> <new-issue-name>
-  ```
+    ```sh
+    $ git push <your-username> <new-issue-name>
+    ```
 
 1. On the GitHub page for your fork and branch, create a [pull request](https://help.github.com/articles/using-pull-requests/) by clicking `Compare & pull request`. Edit the message copied from your commit, adding more detail if needed, then click `Create pull request`.
 


### PR DESCRIPTION
Context: The numbering of the [Making changes to Google Cloud](https://github.com/GoogleCloudPlatform/google-cloud-common/blob/master/contributing/readme.md#making-changes-to-google-cloud) section is being restarted whenever there is a code block between two items. That way, the steps to be repeated in the [Verifying your contribution](https://github.com/GoogleCloudPlatform/google-cloud-common/blob/master/contributing/readme.md#verifying-your-contribution) are confusing.

Changes: Add extra spaces before such code blocks, so that the list numbering isn't restarted every time.

Preview: https://github.com/fmachado091/google-cloud-common/blob/master/contributing/readme.md